### PR TITLE
FIX redis host fix

### DIFF
--- a/etc/src/main/resources/application.yaml
+++ b/etc/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
 
   data:
     redis:
-      host: localhost
+      host: 34.64.88.166
       port: 6379
       password: ${REDIS_PASSWORD}
 

--- a/etc/src/main/resources/application.yaml
+++ b/etc/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ spring:
 
   data:
     redis:
-      host: 34.64.88.166
+      host: localhost
       port: 6379
       password: ${REDIS_PASSWORD}
 


### PR DESCRIPTION
# 변경점 👍
레디스 호스트 설정 ip로 재설정

# 비고 ✏
api호출 시 레디스 캐시 메모리에 접근이 되지 않고 있습니다. 테스트를 위해 data.redis.host의 localhost를 ip로 변경합니다.
